### PR TITLE
Switch from 'whywaita/setup-lxd' to 'canonical/setup-lxd'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,14 +9,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Setup LXD
-        uses: whywaita/setup-lxd@v1
-        with:
-          lxd_version: latest/stable
+        uses: canonical/setup-lxd@main
 
       - name: Install rockcraft
         run: |
           sudo snap install --classic --channel edge rockcraft
+
       - name: Build ROCK
         run: rockcraft pack --verbose
 


### PR DESCRIPTION
Otherwise rockcraft is failing:

https://github.com/canonical/zookeeper-rock/actions/runs/3660242441/jobs/6187153089

> Run rockcraft pack --verbose
>   rockcraft pack --verbose
>   shell: /usr/bin/bash -e {0}
> Starting Rockcraft 0.0.1.dev1
> Logging execution to '/home/runner/.cache/rockcraft/log/rockcraft-20221209-193405.486946.log'
> Launching instance...
> craft-providers error: Failed to install packages.
> * Command that failed: 'lxc --project rockcraft exec local:rockcraft-zookeeper-2604242 -- env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin ROCKCRAFT_MANAGED_MODE=1 apt-get install -y apt-utils curl'
> * Command exit code: 100
> * Command output: b'Reading package lists...\nBuilding dependency tree...\nReading state information...\nPackage apt-utils is not available, but is referred to by another package.\nThis may mean that the package is missing, has been obsoleted, or\nis only available from another source\nHowever the following packages replace it:\n  apt\n\n'
> * Command standard error output: b"E: Package 'apt-utils' has no installation candidate\nE: Unable to locate package curl\n"
> Full execution log: '/home/runner/.cache/rockcraft/log/rockcraft-20221209-193405.486946.log'