### PR TITLE
DPE-1082 Switch from 'whywaita/setup-lxd' to 'canonical/setup-lxd' (#4)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,14 +9,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Setup LXD
-        uses: whywaita/setup-lxd@v1
-        with:
-          lxd_version: latest/stable
+        uses: canonical/setup-lxd@main
 
       - name: Install rockcraft
         run: |
           sudo snap install --classic --channel edge rockcraft
+
       - name: Build ROCK
         run: rockcraft pack --verbose
 


### PR DESCRIPTION
Otherwise rockcraft is failing:

https://github.com/canonical/zookeeper-rock/actions/runs/3660242441/jobs/6187153089

> Run rockcraft pack --verbose
>   rockcraft pack --verbose
>   shell: /usr/bin/bash -e {0}
> Starting Rockcraft 0.0.1.dev1
> Logging execution to '/home/runner/.cache/rockcraft/log/rockcraft-20221209-193405.486946.log'
> Launching instance...
> craft-providers error: Failed to install packages.
> * Command that failed: 'lxc --project rockcraft exec local:rockcraft-zookeeper-2604242 -- env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin ROCKCRAFT_MANAGED_MODE=1 apt-get install -y apt-utils curl'
> * Command exit code: 100
> * Command output: b'Reading package lists...\nBuilding dependency tree...\nReading state information...\nPackage apt-utils is not available, but is referred to by another package.\nThis may mean that the package is missing, has been obsoleted, or\nis only available from another source\nHowever the following packages replace it:\n  apt\n\n'
> * Command standard error output: b"E: Package 'apt-utils' has no installation candidate\nE: Unable to locate package curl\n"
> Full execution log: '/home/runner/.cache/rockcraft/log/rockcraft-20221209-193405.486946.log'

The issue has been reported to rockcraft already:

> https://github.com/canonical/charmcraft/issues/507 =>
> https://github.com/canonical/charmcraft/issues/511 =>
> https://discourse.charmhub.io/t/charmcraft-failing-to-pack-because-of-apt-update-failure/5139 =>
> https://linuxcontainers.org/lxd/docs/master/howto/network_bridge_firewalld/#prevent-issues-with-lxd-and-docker

Note: no docker installed inside 'ubuntu-latest' GH OCI (22.04.1), but docker rules are present:

> Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
>  pkts bytes target     prot opt in     out     source               destination
>
> Chain FORWARD (policy DROP 0 packets, 0 bytes)
>  pkts bytes target     prot opt in     out     source               destination
>     0     0 DOCKER-USER  all  --  *      *       0.0.0.0/0            0.0.0.0/0
>     0     0 DOCKER-ISOLATION-STAGE-1  all  --  *      *       0.0.0.0/0            0.0.0.0/0
>     0     0 ACCEPT     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0            ctstate RELATED,ESTABLISHED
>     0     0 DOCKER     all  --  *      docker0  0.0.0.0/0            0.0.0.0/0
>     0     0 ACCEPT     all  --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0
>     0     0 ACCEPT     all  --  docker0 docker0  0.0.0.0/0            0.0.0.0/0
>
> Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
>  pkts bytes target     prot opt in     out     source               destination
>
> Chain DOCKER (1 references)
>  pkts bytes target     prot opt in     out     source               destination
>
> Chain DOCKER-ISOLATION-STAGE-1 (1 references)
>  pkts bytes target     prot opt in     out     source               destination
>     0     0 DOCKER-ISOLATION-STAGE-2  all  --  docker0 !docker0  0.0.0.0/0            0.0.0.0/0
>     0     0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0
>
> Chain DOCKER-ISOLATION-STAGE-2 (1 references)
>  pkts bytes target     prot opt in     out     source               destination
>     0     0 DROP       all  --  *      docker0  0.0.0.0/0            0.0.0.0/0
>     0     0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0
>
> Chain DOCKER-USER (1 references)
>  pkts bytes target     prot opt in     out     source               destination
>     0     0 RETURN     all  --  *      *       0.0.0.0/0            0.0.0.0/0

The canonical/setup-lxd is configuring iptables properly.

(cherry picked from commit e070710b7cbb5bb2fd9f53ded07c3836bb9b68fd)